### PR TITLE
Drop John the Ripper potfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # graphcat.py
 
-Simple script to generate graphs and charts on hashcat (and john) potfile and ntds.
+Simple script to generate graphs and charts on hashcat potfile and ntds.
 
 ## Table of Content
 
@@ -32,32 +32,32 @@ pip install .
 
 ```text
 $ graphcat.py -h
-usage: graphcat.py [-h] -potfile hashcat.potfile -hashfile hashfile.txt [-john] [-format FORMAT] [-export-charts] [-output-dir OUTPUT_DIR] [-debug]
+usage: graphcat.py [-h] -p hashcat.potfile -H hashfile.txt [-f FORMAT] [-e] [-o OUTPUT_DIR] [-d]
 
 Password Cracking Graph Reporting
 
 options:
   -h, --help            show this help message and exit
-  -potfile hashcat.potfile
-                        Hashcat Potfile
-  -hashfile hashfile.txt
+  -p hashcat.potfile, --potfile hashcat.potfile
+                        Hashcat potfile
+  -H hashfile.txt, --hashfile hashfile.txt
                         File containing hashes (one per line)
-  -john                 John potfile
-  -format FORMAT        hashfile format (default 3): 1 for hash; 2 for username:hash; 3 for secretsdump (username:uid:lm:ntlm)
-  -export-charts        Output also charts in png
-  -output-dir OUTPUT_DIR
+  -f FORMAT, --format FORMAT
+                        hashfile format (default 3): 1 for hash; 2 for username:hash; 3 for secretsdump (username:uid:lm:ntlm)
+  -e, --export-charts   Output also charts in png
+  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Output directory
-  -debug                Turn DEBUG output ON
+  -d, --debug           Turn DEBUG output ON
 ```
 
 ## Usage
 
-Graphcat just needs a potfile with `-potfile` (default is hashcat, but you can use `-john` to submit a john potfile) and a hashfile with `-hashfile`. The hashfile should be in a specific format from the [3 availables formats](#formats) with `-format` flag. Default is **Secretsdump**.
+Graphcat just needs a potfile with `-p/--potfile` (hashcat potfile) and a hashfile with `-H/--hashfile`. The hashfile should be in a specific format from the [3 availables formats](#formats) with `-f/--format` flag. Default is **Secretsdump**.
 
 The tool will generate a report with multiple password cracking charts. You can get charts in png with the `-export-charts` flag.
 
 ```text
-$ graphcat.py -hashfile entreprise.local.ntds -potfile hashcat.pot
+$ graphcat.py -H entreprise.local.ntds -p hashcat.pot
 [-] Parsing potfile
 [-] 95 entries in potfile
 [-] Parsing hashfile

--- a/graphcat.py
+++ b/graphcat.py
@@ -190,24 +190,19 @@ class GraphCat:
         self.potfile = None
         self.hashes = None
         self.outputdir = '.'
-        if options.output_dir is not None:
-            self.outputdir = options.output_dir
+        if self.options.output_dir is not None:
+            self.outputdir = self.options.output_dir
             if not os.path.isdir(self.outputdir):
                 os.makedirs(self.outputdir, exist_ok=True)
 
         print('[-] Parsing potfile')
-        if options.potfile is not None:
+        if self.options.potfile is not None:
             arr = dict()
-            with open(options.potfile, 'r') as lines:
+            with open(self.options.potfile, 'r') as lines:
                 for line in lines:
                     l = line.rstrip('\n')
                     if ':' in l:
                         l = l.split(':',1)
-                        if options.john:
-                            if '$NT$' in l[0]:
-                                l[0] = l[0].replace('$NT$','')
-                            else:
-                                continue
                         arr[l[0].lower()]=l[1]
                 self.potfile = arr
         if len(self.potfile) == 0:
@@ -216,13 +211,13 @@ class GraphCat:
         print('[-] %s entries in potfile' % len(self.potfile))
 
         print('[-] Parsing hashfile')
-        if options.hashfile is not None:
-            
-            with open(options.hashfile, 'r') as lines:
-                if options.format in ['1','2']:
+        if self.options.hashfile is not None:
+
+            with open(self.options.hashfile, 'r') as lines:
+                if self.options.format in ['1','2']:
                     self.hashes = [line.rstrip('\n') for line in lines ]
-                elif options.format == '3':
-                    self.hashes = [line.rstrip('\n').split(':::')[0] for line in lines 
+                elif self.options.format == '3':
+                    self.hashes = [line.rstrip('\n').split(':::')[0] for line in lines
                     if '$:' not in line and '$_history' not in line and ':::' in line]
                 else:
                     print('[!] Unknown format')
@@ -263,7 +258,11 @@ class GraphCat:
 
         plt.clf()
         plt.figure(figsize=[15, 7])
-        text_prop = {'fontsize':'x-large', 'fontweight':'heavy', 'color':'black', 'fontsize': 20}
+        text_prop = {
+            'fontsize': 20,
+            'fontweight': 'heavy',
+            'color': 'black',
+        }
 
         plt.pie(found.values(),
                 wedgeprops={'edgecolor':'White','linewidth': 5,'antialiased': True},
@@ -309,7 +308,11 @@ class GraphCat:
         
         plt.clf()
         plt.figure(figsize=[15, 7])
-        text_prop = {'fontsize':'x-large', 'fontweight':'heavy', 'color':'black', 'fontsize': 20}
+        text_prop = {
+            'fontsize': 20,
+            'fontweight': 'heavy',
+            'color': 'black',
+        }
         
         plt.pie(tmp_format.values(),
                 wedgeprops={'edgecolor':'White','linewidth': 5,'antialiased': True},
@@ -431,7 +434,11 @@ class GraphCat:
         if history_reuse > 0:
             plt.clf()
             plt.figure(figsize=[15, 7])
-            text_prop = {'fontsize':'x-large', 'fontweight':'heavy', 'color':'black', 'fontsize': 20}
+            text_prop = {
+                'fontsize': 20,
+                'fontweight': 'heavy',
+                'color': 'black',
+            }
             plt.pie([history_reuse, len(self.cracked_users.values()) - history_reuse], 
                     wedgeprops={'edgecolor':'White','linewidth': 5,'antialiased': True},
                     textprops=text_prop,
@@ -538,7 +545,7 @@ class GraphCat:
         users = dict()
         userhist_lines = list()
 
-        if options.format == '1':
+        if self.options.format == '1':
             i = 0
             for hash in self.hashes:
                 cleartext = None
@@ -547,7 +554,7 @@ class GraphCat:
                     cleartext = self.potfile[hash]
                 users[f'user_{i}']=User(f'user_{i}', hash, cleartext)
                 i += 1
-        elif options.format == '2':
+        elif self.options.format == '2':
             for line in self.hashes:
                 username, hash = line.split(':')
                 hash = hash.lower()
@@ -555,7 +562,7 @@ class GraphCat:
                 if hash in self.potfile.keys():
                     cleartext = self.potfile[hash]
                 users[username]=User(username, hash, cleartext)
-        elif options.format == '3':
+        elif self.options.format == '3':
             for line in self.hashes:
                 if '_history' in line:
                     userhist_lines.append(line)
@@ -599,26 +606,33 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
-        "-potfile",
+        "-p", "--potfile",
         action="store",
         required=True,
         metavar="hashcat.potfile",
-        help="Hashcat Potfile",
+        help="Hashcat potfile",
     )
 
     parser.add_argument(
-        "-hashfile",
+        "-H", "--hashfile",
         action="store",
         required=True,
         metavar="hashfile.txt",
         help="File containing hashes (one per line)",
     )
 
-    parser.add_argument("-john", action="store_true", help="John potfile")
-    parser.add_argument("-format", action="store", default="3", help="hashfile format (default 3): 1 for hash; 2 for username:hash; 3 for secretsdump (username:uid:lm:ntlm)")
-    parser.add_argument("-export-charts", action="store_true", help="Output also charts in png")
-    parser.add_argument("-output-dir", action="store", help="Output directory")
-    parser.add_argument("-debug", action="store_true", help="Turn DEBUG output ON")
+    parser.add_argument(
+        "-f", "--format",
+        action="store",
+        default="3",
+        help=(
+            "hashfile format (default 3): 1 for hash; 2 for username:hash; "
+            "3 for secretsdump (username:uid:lm:ntlm)"
+        ),
+    )
+    parser.add_argument("-e", "--export-charts", action="store_true", help="Output also charts in png")
+    parser.add_argument("-o", "--output-dir", action="store", help="Output directory")
+    parser.add_argument("-d", "--debug", action="store_true", help="Turn DEBUG output ON")
 
     options = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- simplify potfile parsing
- drop `-john` flag from CLI
- update README to mention hashcat-only support
- modernize CLI flags (e.g. `-p/--potfile`, `-H/--hashfile`, `-f/--format`)
- stop relying on global options inside GraphCat
- fix duplicate key bug in pie chart text props

## Testing
- `python -m py_compile graphcat.py`


------
https://chatgpt.com/codex/tasks/task_e_684410249d4883268cb82db97f2942a8