### PR TITLE
Refine output behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generate graphs and charts from Hashcat potfiles and NTDS dumps.
 - [Formats](#formats)
 - [Charts Example](#charts-example)
 
-## Installation 🚀
+## Installation
 
 ### Prerequisite
 ```text

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
-# graphcat.py
+# Graphcat-ng
 
-Simple script to generate graphs and charts on hashcat potfile and ntds.
+Generate graphs and charts from Hashcat potfiles and NTDS dumps.
 
-## Table of Content
+* PDF report with password cracking statistics
+* 📊 Automatic PNG charts stored alongside the report
+* English and French support
 
-- [graphcat.py](#graphcatpy)
-  - [Table of Content](#table-of-content)
-  - [Install](#install)
-  - [Helper](#helper)
-  - [Usage](#usage)
-  - [Format](#formats)
-  - [Charts example](#charts-example)
+## Table of Contents
 
-## Install
+- [Installation](#installation-)
+- [Helper](#helper)
+- [Usage](#usage)
+- [Formats](#formats)
+- [Charts Example](#charts-example)
+
+## Installation 🚀
 
 ### Prerequisite
 ```text
 apt install python3-venv
 ```
 
-### Installation
+### Steps
 ```text
 git clone https://github.com/WodenSec/graphcat-ng
 cd graphcat-ng
@@ -32,7 +34,7 @@ pip install .
 
 ```text
 $ graphcat.py -h
-usage: graphcat.py [-h] -p hashcat.potfile -H hashfile.txt [-f FORMAT] [-e] [-o OUTPUT_DIR] [-d]
+usage: graphcat.py [-h] -p hashcat.potfile -H hashfile.txt [-f FORMAT] [-o OUTPUT_DIR] [-d]
 
 Password Cracking Graph Reporting
 
@@ -45,7 +47,6 @@ options:
   -f FORMAT, --format FORMAT
                         hashfile format (default 3): 1 for hash; 2 for username:hash; 3 for secretsdump (username:uid:lm:ntlm)
   --french              Generate report in French
-  -e, --export-charts   Output also charts in png
   -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Output directory
   -d, --debug           Turn DEBUG output ON
@@ -53,9 +54,9 @@ options:
 
 ## Usage
 
-Graphcat just needs a potfile with `-p/--potfile` (hashcat potfile) and a hashfile with `-H/--hashfile`. The hashfile should be in a specific format from the [3 availables formats](#formats) with `-f/--format` flag. Default is **Secretsdump**.
+Provide a potfile with `-p/--potfile` and a hash list with `-H/--hashfile`. The hashes must follow one of the [three supported formats](#formats) (default: **Secretsdump**).
 
-The tool will generate a report with multiple password cracking charts. You can get charts in png with the `-export-charts` flag.
+Graphcat will build a full report with password cracking charts and automatically save the graphs as PNG files.
 
 ```text
 $ graphcat.py -H entreprise.local.ntds -p hashcat.pot
@@ -64,7 +65,7 @@ $ graphcat.py -H entreprise.local.ntds -p hashcat.pot
 [-] Parsing hashfile
 [-] 923 entries in hashfile
 [-] Generating graphs...
-Results directory: ./results_1723406377
+Results directory: ./results_2025-06-14_17-35-49
 [-] Generating report...
 ```
 
@@ -73,32 +74,32 @@ Results directory: ./results_1723406377
 1: Only Hash
 
 ```text
-aad3b435b51404eeaad3b435b51404ee
-aad3b435b51404eeaad3b435b51404ee
-aad3b435b51404eeaad3b435b51404ee
+31d6cfe0d16ae931b73c59d7e0c089c0
+31d6cfe0d16ae931b73c59d7e0c089c0
+31d6cfe0d16ae931b73c59d7e0c089c0
 ```
 
 2: Username + Hash
 
 ```text
-test1:aad3b435b51404eeaad3b435b51404ee
-test2:aad3b435b51404eeaad3b435b51404ee
-test3:aad3b435b51404eeaad3b435b51404ee
+test1:31d6cfe0d16ae931b73c59d7e0c089c0
+test2:31d6cfe0d16ae931b73c59d7e0c089c0
+test3:31d6cfe0d16ae931b73c59d7e0c089c0
 ```
 
 3: Secretsdump
 
 ```text
-waza.local\test1:4268:aad3b435b51404eeaad3b435b51404ee:aad3b435b51404eeaad3b435b51404ee:::
-waza.local\test2:4269:aad3b435b51404eeaad3b435b51404ee:aad3b435b51404eeaad3b435b51404ee:::
-waza.local\test3:4270:aad3b435b51404eeaad3b435b51404ee:aad3b435b51404eeaad3b435b51404ee:::
+waza.local\test1:4268:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+waza.local\test2:4269:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+waza.local\test3:4270:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
 ```
 
 If a hash occurs more than once in the hash file, it will be counted that many times.
 
 Moreover, if you submit secretsdump with password history (`-history` in secretsdump command), it will analyze similarity in password history
 
-## Charts example
+## Charts Example
 
 <img title="Cracked" src="./assets/cracked.png">
 <img title="Format repartition" src="./assets/format.png">

--- a/graphcat.py
+++ b/graphcat.py
@@ -2,7 +2,6 @@
 
 import argparse
 from collections import Counter
-import calendar
 import time
 import os
 import re
@@ -63,7 +62,7 @@ class GraphCat:
         self.options = options
         self.trans = TRANSLATIONS['fr'] if self.options.french else TRANSLATIONS['en']
 
-        self.timestamp = calendar.timegm(time.gmtime())
+        self.timestamp = time.strftime("%Y-%m-%d_%H-%M-%S", time.gmtime())
         self.potfile = None
         self.hashes = None
         self.outputdir = '.'
@@ -158,9 +157,6 @@ class GraphCat:
         fig.gca().add_artist(centre_circle)
 
         plt.savefig(os.path.join(dirpath,'cracked.png'), dpi=118)
-        if self.options.export_charts:
-            print('[-] Cracked charts available at cracked.png')
-            plt.savefig(os.path.join(self.outputdir,'cracked.png'), dpi=118)
 
         # Pie N°2 : Format
 
@@ -204,9 +200,6 @@ class GraphCat:
         fig.gca().add_artist(centre_circle)
 
         plt.savefig(os.path.join(dirpath,'format.png'), dpi=118)
-        if self.options.export_charts:
-            print('[-] Password format repartition available at format.png')
-            plt.savefig(os.path.join(self.outputdir,'format.png'), dpi=118)
 
         # Pie N°3 : Length repartition
 
@@ -240,9 +233,6 @@ class GraphCat:
         for i in range(len(x)):
             plt.text(i, y[i]+(longueur_max/100*1.5), y[i], ha = 'center')
         plt.savefig(os.path.join(dirpath,'length.png'), dpi=118)
-        if self.options.export_charts:
-            print('[-] Password length repartition available at length.png')
-            plt.savefig(os.path.join(self.outputdir,'length.png'), dpi=118)
 
         # Pie N°4 and N°5 : Top 10 most cracked and Top 10 basewords
 
@@ -275,9 +265,6 @@ class GraphCat:
         for i in range(len(x)):
             plt.text(i, y[i]+(most_max/100*1.5), y[i], ha = 'center')
         plt.savefig(os.path.join(dirpath,'most.png'), dpi=118)
-        if self.options.export_charts:
-            print('[-] Top10 most cracked password at most.png')
-            plt.savefig(os.path.join(self.outputdir,'most.png'), dpi=118)
 
         basewords = dict()
         for key, value in c2.most_common(10):
@@ -297,9 +284,6 @@ class GraphCat:
         for i in range(len(x)):
             plt.text(i, y[i]+(baseword_max/100*1.5), y[i], ha = 'center')
         plt.savefig(os.path.join(dirpath,'basewords.png'), dpi=118)
-        if self.options.export_charts:
-            print('[-] Top10 basewords at basewords.png')
-            plt.savefig(os.path.join(self.outputdir,'basewords.png'), dpi=118)
 
         common_masks = dict()
         for key, value in c3.most_common(10):
@@ -333,9 +317,6 @@ class GraphCat:
             fig.gca().add_artist(centre_circle)
 
             plt.savefig(os.path.join(dirpath,'history.png'), dpi=118)
-            if self.options.export_charts:
-                print('[-] History analysis at history.png')
-                plt.savefig(os.path.join(self.outputdir,'history.png'), dpi=118)
             
         # Generate pdf report based on htlm template
         print('[-] Generating report...')
@@ -386,7 +367,8 @@ class GraphCat:
                             )
 
         with open(os.path.join(dirpath,'report.html'), 'w') as f:
-            f.write(html)  
+            f.write(html)
+        os.remove(os.path.join(dirpath, 'template.html'))
 
     def isNaN(self,num):
         return num!= num
@@ -526,7 +508,6 @@ if __name__ == '__main__':
         ),
     )
     parser.add_argument("--french", action="store_true", help="Generate report in French")
-    parser.add_argument("-e", "--export-charts", action="store_true", help="Output also charts in png")
     parser.add_argument("-o", "--output-dir", action="store", help="Output directory")
     parser.add_argument("-d", "--debug", action="store_true", help="Turn DEBUG output ON")
 


### PR DESCRIPTION
## Summary
- generate results folders with readable timestamps
- remove `--export-charts` option and always store images in the results folder
- clean up temporary `template.html` after report generation
- refresh README instructions and examples with new timestamp and minimal emoji

## Testing
- `python3 -m py_compile graphcat.py`
- `python3 graphcat.py -h | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684d92265e2083268b4876017848e4b2